### PR TITLE
Fix missing libwebkitgtk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,15 +22,20 @@ RUN wget https://downloads.sourceforge.net/project/jtds/jtds/1.3.1/jtds-1.3.1-di
 	&& unzip Jaybird-3.0.4-JDK_1.8.zip -d lib \
 	&& rm -rf lib/docs/ Jaybird-3.0.4-JDK_1.8.zip
 
+# Adictional Setup
+COPY ./setup.sh /
+RUN chmod +x /setup.sh \
+	&& . /setup.sh
+
+# Install xauth
+RUN apt-get update && apt-get install -y xauth libwebkitgtk-1.0-0
+
 # First time run
 RUN pan.sh -file ./plugins/platform-utils-plugin/samples/showPlatformVersion.ktr \
 	&& kitchen.sh -file samples/transformations/files/test-job.kjb
 
-# Install xauth
-RUN apt-get update && apt-get install -y xauth
-
 #VOLUME /jobs
 
-COPY entrypoint.sh /
+COPY ./entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["help"]

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ sudo curl -fsSL https://raw.githubusercontent.com/andrespp/docker-pdi/master/s
 $ sudo chmod +x /usr/local/bin/spoon
 ```
 
-Then you'll be able to run JupyterLab in the current directory simply by calling `jlab`:
+Then you'll be able to run spoon in the current directory simply by calling `spoon`:
 
 ```bash
 $ spoon

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+## Add  libwebkitgtk repository
+echo deb 'http://cz.archive.ubuntu.com/ubuntu bionic main universe' >> /etc/apt/sources.list
+
+## Add repository PUB_KEY
+KEYS=$(apt update 2>&1 1>/dev/null | sed -ne 's/.*NO_PUBKEY //p')
+echo $KEYS | while read key; do apt-key adv --keyserver hkp://pool.sks-keyservers.net:80 --recv-keys "$key"; done


### PR DESCRIPTION
Fix error to execute spoon

```
WARNING:  no libwebkitgtk-1.0 detected, some features will be unavailable
    Consider installing the package with apt-get or yum.
    e.g. 'sudo apt-get install libwebkitgtk-1.0-0'
```
